### PR TITLE
Update generateUniqueKey JSDoc to match recent changes

### DIFF
--- a/build/register.js
+++ b/build/register.js
@@ -34,7 +34,7 @@ randomstring = require('randomstring');
  *
  * @example
  * randomKey = deviceRegister.generateUniqueKey()
- * randomKey is a randomly generated key that can be used as either a uuid or an api key
+ * # randomKey is a randomly generated key that can be used as either a uuid or an api key
  * console.log(randomKey)
  */
 

--- a/build/register.js
+++ b/build/register.js
@@ -30,16 +30,12 @@ randomstring = require('randomstring');
  * @function
  * @public
  *
- * @description
- * This function allows promise style if the callback is omitted.
- *
- * @param {Function} callback - callback (error, randomKey)
+ * @returns {String} A generated key
  *
  * @example
- * deviceRegister.generateUniqueKey (error, randomKey) ->
- *  	throw error if error?
- * 	# randomKey is a randomly generated key that can be used as either a uuid or an api key
- * 	console.log(randomKey)
+ * randomKey = deviceRegister.generateUniqueKey()
+ * randomKey is a randomly generated key that can be used as either a uuid or an api key
+ * console.log(randomKey)
  */
 
 exports.generateUniqueKey = function() {

--- a/lib/register.coffee
+++ b/lib/register.coffee
@@ -27,7 +27,7 @@ randomstring = require('randomstring')
 #
 # @example
 # randomKey = deviceRegister.generateUniqueKey()
-# randomKey is a randomly generated key that can be used as either a uuid or an api key
+# # randomKey is a randomly generated key that can be used as either a uuid or an api key
 # console.log(randomKey)
 ###
 exports.generateUniqueKey = ->

--- a/lib/register.coffee
+++ b/lib/register.coffee
@@ -23,16 +23,12 @@ randomstring = require('randomstring')
 # @function
 # @public
 #
-# @description
-# This function allows promise style if the callback is omitted.
-#
-# @param {Function} callback - callback (error, randomKey)
+# @returns {String} A generated key
 #
 # @example
-# deviceRegister.generateUniqueKey (error, randomKey) ->
-#  	throw error if error?
-# 	# randomKey is a randomly generated key that can be used as either a uuid or an api key
-# 	console.log(randomKey)
+# randomKey = deviceRegister.generateUniqueKey()
+# randomKey is a randomly generated key that can be used as either a uuid or an api key
+# console.log(randomKey)
 ###
 exports.generateUniqueKey = ->
 	# It'd be nice if the random key matched the output of a SHA-256 function,


### PR DESCRIPTION
The changes in #22 changed generateUUID to generateUniqueKey, made the method synchronous, and updated the README, but didn't completely update the JSDoc.

This PR pulls the correct README documentation into the JSDoc too.